### PR TITLE
Added obsidian block to mining skill

### DIFF
--- a/plugins/EcoSkills/skills/mining.yml
+++ b/plugins/EcoSkills/skills/mining.yml
@@ -265,6 +265,12 @@ xp-gain-methods:
       blocks:
         - budding_amethyst
 
+  - trigger: mine_block
+    multiplier: 10
+    filters:
+      player_placed: false
+      blocks:
+        - obsidian
 # Conditions that must be met to gain XP. While you can add conditions to xp
 # gain methods, if you have many this can be annoying, so this is global.
 conditions: [ ]

--- a/plugins/EcoSkills/skills/mining.yml
+++ b/plugins/EcoSkills/skills/mining.yml
@@ -228,6 +228,7 @@ xp-gain-methods:
       blocks:
         - gilded_blackstone
         - diamond_ore
+        - obsidian
 
   - trigger: mine_block
     multiplier: 10.5
@@ -265,12 +266,6 @@ xp-gain-methods:
       blocks:
         - budding_amethyst
 
-  - trigger: mine_block
-    multiplier: 10
-    filters:
-      player_placed: false
-      blocks:
-        - obsidian
 # Conditions that must be met to gain XP. While you can add conditions to xp
 # gain methods, if you have many this can be annoying, so this is global.
 conditions: [ ]


### PR DESCRIPTION
## Suggestion by naranja0113:
Add *obsidian* to **mining** skill from **EcoSkills**

Multiplayer set to `10` because:
 - Mining efficiency
 - Less than `deepslate_diamond_ore`
 - Equal as `diamond_ore`
 - Cannot get xp from a block placed by a **player**